### PR TITLE
Fixed missing required packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ gem "github-pages"
 gem "just-the-docs"
 gem "jekyll-remote-theme"
 gem 'jemoji'
+
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
Webrick is not included by default in recent versions, needed to serve the website. See https://stackoverflow.com/questions/69890412/bundler-failed-to-load-command-jekyll